### PR TITLE
Docs Link Edit

### DIFF
--- a/docs/css-comb.md
+++ b/docs/css-comb.md
@@ -11,4 +11,4 @@ Here is a link to the Sublime Text [User Settings][2]
 
 
   [1]: http://csscomb.com/
-  [2]: sublime-text-settings.md
+  [2]: https://github.com/ebsco/edna/blob/develop/docs/sublime-text-settings.md


### PR DESCRIPTION
Changing the link to the CSS Comb user preferences for Sublime Text. The old one wasn't working in confluence because it was relative not absolute and clicking on the link brought up nothing. :cry: 
