### PR TITLE
Layout Fixes

### DIFF
--- a/less/_layout-mq.less
+++ b/less/_layout-mq.less
@@ -2,7 +2,7 @@
 @media @mq-sm {
     [class*="l"][class*="-p"] {
 		.col {
-			display: table;
+			display: block;
 			width: 100%;
 			+ .col {
 				padding-left: 0;
@@ -15,7 +15,7 @@
 @media @mq-md {
     [class*="l"][class*="-p"] {
 		.col {
-			display: table;
+			display: block;
 			width: 100%;
 			+ .col {
 				padding-left: 0;


### PR DESCRIPTION
Changing this from table to block so it functions better at certain breakpoints.

I was trying to make some tables scroll left and right at certain breakpoints, but the `display: table;` made them bust out of a parent element. They need to respect their parent elements `overflow: scroll;`. By changing this to `display: block;` they do respect it.

:smile: :+1: 
