### PR TITLE
Splitting selector. IE8 wasn't accepting the selector after encountering...

### DIFF
--- a/less/_mixins.less
+++ b/less/_mixins.less
@@ -47,17 +47,23 @@
 //----- CLEARFIX --------------------------------------//
 
 // ie7
-.clearfix() {
+.clearfix {
 	*zoom: 1;
 	&:before,
-	&:after,
+	&:after {
+		display: table;
+		line-height: 0;
+		content: "";
+	}
 	&::before,
 	&::after {
 		display: table;
 		line-height: 0;
 		content: "";
 	}
-	&:after,
+	&:after {
+		clear: both;
+	}
 	&::after {
 		clear: both;
 	}


### PR DESCRIPTION
... invalid parts, and we still need the clearfix there.
