### PR TITLE
Removes horizontal highlight spacing.

### DIFF
--- a/less/_universal.less
+++ b/less/_universal.less
@@ -3,9 +3,9 @@
 // styles that are universal
 
 html & {
-	height: 100%;
-
 	.box(border);
+
+	height: 100%;
 }
 
 *,
@@ -49,8 +49,8 @@ body {
 .highlight {
 	@space: 2px;
 
-	padding: @space;
-	margin: -@space;
+	padding-top: @space;
+	padding-bottom: @space;
 
 	background-color: @highlight-bgcolor;
 }


### PR DESCRIPTION
Can't seem to affect z index of a span with text that comes before it.
