### PR TITLE
Removes hover from li, this doesn't align with the markup.

### DIFF
--- a/less/_treelist.less
+++ b/less/_treelist.less
@@ -44,11 +44,6 @@
 		.list-item {
 			padding: 0;
 			margin: 0;
-			&:hover {
-				.txt-link {
-					text-decoration: underline;
-				}
-			}
 		}
 		.txt-link {
 			.fontsize(1.4);
@@ -60,6 +55,7 @@
 			font-weight: normal;
 			color: @treelist-color;
 			cursor: pointer;
+
 			border: none;
 		}
 		&.active {


### PR DESCRIPTION
There is also an svg for expand/collapse under the li. Hovering over that should not underline the text, so removing this style.
