### PR TITLE
Media stylesheet #88

### DIFF
--- a/edna.less
+++ b/edna.less
@@ -21,7 +21,6 @@
 @import 'less/_grid.less';
 @import 'less/_list.less';
 @import 'less/_logo.less';
-@import 'less/_media.less';
 @import 'less/_mediablock.less';
 @import 'less/_messaging.less';
 @import 'less/_modal.less';

--- a/less/_media.less
+++ b/less/_media.less
@@ -1,7 +1,0 @@
-/* MEDIA */
-
-.img {
-	a & {
-		display: block;
-	}
-}

--- a/less/_svg.less
+++ b/less/_svg.less
@@ -53,6 +53,15 @@
 // 
 // Styleguide 19.1
 
+// add some basic styles to icons
+.icon {
+	display: inline-block;
+	width: 25px;
+	height: 25px;
+
+	background-position: top center;
+}
+
 [class*='svg-'] {
 	background-position: center center;
 	background-repeat: no-repeat;

--- a/less/_universal.less
+++ b/less/_universal.less
@@ -29,17 +29,9 @@ body {
 		padding-left: 70px;
 	}
 }
-
+// for bits like the close button on a modal, seems like this should be elsewhere...
 .close {
 	cursor: pointer;
-}
-
-.icon {
-	display: inline-block;
-	width: 25px;
-	height: 25px;
-
-	background-position: top center;
 }
 
 .visible {
@@ -57,4 +49,11 @@ body {
 
 .selected.highlight {
 	background-color: @selected-highlight-bgcolor;
+}
+
+// get rid of that nasty space under an image when it's wrapped in an anchor
+.img {
+	a & {
+		display: block;
+	}
 }


### PR DESCRIPTION
- removing the file `_media.less` stylesheet because the stuff in it has moved
- moving image styles from the `_media.less` stylesheet to the universal one because it feels silly having a whole stylesheet for only five lines. also moving the `.icon` declaration block into the `_svg.less` stylesheet since it fits better there

enjoy
