### PR TITLE
readding the % formatting. csslint did not like rgba in the filter.

### DIFF
--- a/less/_mixins.less
+++ b/less/_mixins.less
@@ -108,7 +108,7 @@
 	background-image:  -ms-linear-gradient(bottom, @bottom, @top);
 	background-image:   -o-linear-gradient(@top, @bottom);
 	background-image:      linear-gradient(@top, @bottom);
-	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=@top, endColorstr=@bottom, gradientType='0');
+	filter: %("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@top,@bottom);
 }
 
 


### PR DESCRIPTION
It appears that it was the css escaping, e() that was messing the mixin in ie. This should fix the Edna build
