### PR TITLE
removing another reference to filter that uses the e() escape method.

### DIFF
--- a/less/_mixins.less
+++ b/less/_mixins.less
@@ -288,7 +288,7 @@
 	background: -moz-linear-gradient(center bottom, @bottom 0%, @top 100%);
 	background:  -ms-linear-gradient(bottom, @bottom, @top);
 	background:   -o-linear-gradient(@top, @bottom);
-	filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@top,@bottom));
+	filter: %("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@top,@bottom);
 }
 
 


### PR DESCRIPTION
The defect was reopened. I'm not entirely sure why it seemed fixed last time. However it looks much better in IE7 now.
