### PR TITLE
GruntIcon 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-less": "^0.12.0",
     "grunt-contrib-watch": "^0.5.3",
     "grunt-express": "^1.4.1",
-    "grunt-grunticon": "~1.2.13",
+    "grunt-grunticon": "~2.0.0",
     "grunt-kss": "^2.0.0",
     "grunt-shell": "^1.1.1"
   },


### PR DESCRIPTION
**WIP**
_(no plans to merge yet, just getting this PR going just so we can remember where things are at)_

new version of GruntIcon. Went with `~2.0.0` because going with the latest version, `2.2.1`, caused errors when running `npm install`

/cc @gjjones 
