### PR TITLE
Removes coloring from bold class.

### DIFF
--- a/less/_typography.less
+++ b/less/_typography.less
@@ -136,7 +136,6 @@ b,
 strong,
 .bold {
 	font-weight: bold;
-	color: @font-color-strong;
 }
 
 em {


### PR DESCRIPTION
Removing the color from the bold class, it is not a property that should be set on a class that only has the intent to affect font-weight.
