### PR TITLE
getting rid of alphaimageloader

### DIFF
--- a/grunticon/rule.hbs
+++ b/grunticon/rule.hbs
@@ -1,6 +1,4 @@
 {{#each customselectors}}{{this}},{{/each}}
 {{prefix}}{{name}} {
 	background-image: url('{{datauri}}');
-	filter: progid:DXImageTransform.Microsoft.AlphaImageLoader( src='{{datauri}}', sizingMethod='scale');
-	-ms-filter: "progid:DXImageTransform.Microsoft.AlphaImageLoader( src='{{datauri}}', sizingMethod='scale')";
 }


### PR DESCRIPTION
Getting rid of AlphaImageloader because it is pretty much garbage and loads images from reference to the document as opposed to the css file it is being used in.
