### PR TITLE
rename label to option-text to prevent clashing dropdowns and input f…

### DIFF
--- a/less/_select.less
+++ b/less/_select.less
@@ -1,11 +1,11 @@
 // Select
-// 
+//
 // This should take the place of the dropdown, and is our version of a select menu.
-// 
+//
 // Styleguide 12
 
 // Select
-// 
+//
 // Markup:
 // <div class="btn btn-group select">
 //     Select
@@ -25,10 +25,10 @@
 //         </div>
 //     </div>
 // </div>
-// 
+//
 // .select-list			- Default
 // .select-list.active	- After user action
-// 
+//
 // Styleguide 12.1
 
 .select {
@@ -102,7 +102,7 @@
 		&.active {
 			display: inline-block;
 		}
-		.label {
+		.option-text {
 			.fontsize(1.4);
 
 			display: block;


### PR DESCRIPTION
rename label to option-text to prevent clashing dropdowns and input fields where other fields have labels on them. 
